### PR TITLE
Replace wait with task.wait

### DIFF
--- a/FULL_DEBUG_GUIDE.md
+++ b/FULL_DEBUG_GUIDE.md
@@ -229,7 +229,7 @@ while true do
         end
     end
     
-    wait(1)
+    task.wait(1)
 end
 ```
 

--- a/Steal_Brainrot_GUI_Guide.md
+++ b/Steal_Brainrot_GUI_Guide.md
@@ -130,12 +130,12 @@ local function AutoCollectItems()
                     local part = item:FindFirstChild("Handle") or item:FindFirstChild("Part")
                     if part and (rootPart.Position - part.Position).Magnitude < 50 then
                         SafeTeleport(part.Position)
-                        wait(0.1)
+                        task.wait(0.1)
                     end
                 end
             end
         end
-        wait(0.5)
+        task.wait(0.5)
     end
 end
 
@@ -155,7 +155,7 @@ local function AutoStealFunction()
                 end
             end
         end
-        wait(1)
+        task.wait(1)
     end
 end
 
@@ -173,7 +173,7 @@ local function AutoBuyFunction()
                 end
             end
         end
-        wait(2)
+        task.wait(2)
     end
 end
 ```
@@ -198,7 +198,7 @@ local AutoFarmToggle = MainTab:CreateToggle({
             while AutoFarm do
                -- Logic auto farm ici
                AutoCollectItems()
-               wait(1)
+               task.wait(1)
             end
          end)
       end

--- a/steal_brainrot.lua
+++ b/steal_brainrot.lua
@@ -364,15 +364,15 @@ local function AutoBuyBrainrots()
                 DebugLog("📍 Étape 1: Se téléporter à côté du brainrot")
                 local nearPosition = brainrot.position + Vector3.new(3, 2, 3) -- Position à côté
                 humanoidRootPart.CFrame = CFrame.new(nearPosition)
-                wait(1)
+                task.wait(1)
                 
                 -- Étape 2: Essayer d'acheter avec E
                 DebugLog("💰 Étape 2: Tentative d'achat avec E")
                 local VirtualInputManager = game:GetService("VirtualInputManager")
                 VirtualInputManager:SendKeyEvent(true, Enum.KeyCode.E, false, game)
-                wait(0.1)
+                task.wait(0.1)
                 VirtualInputManager:SendKeyEvent(false, Enum.KeyCode.E, false, game)
-                wait(1)
+                task.wait(1)
                 
                 -- Étape 3: Suivre le brainrot vers la base
                 DebugLog("🏃 Étape 3: Suivi du brainrot vers la base")
@@ -418,7 +418,7 @@ local function AutoBuyBrainrots()
                             end
                         end)
                         
-                        wait(1) -- Attendre 1 seconde entre chaque suivi
+                        task.wait(1) -- Attendre 1 seconde entre chaque suivi
                     end
                     
                     DebugLog("✅ Processus d'achat terminé pour " .. brainrot.name)
@@ -445,7 +445,7 @@ local ESPToggle = ESPTab:CreateToggle({
          spawn(function()
             while ESPEnabled do
                UpdateESP()
-               wait(3) -- Mise à jour toutes les 3 secondes
+               task.wait(3) -- Mise à jour toutes les 3 secondes
             end
          end)
       else
@@ -485,7 +485,7 @@ local AutoBuyToggle = AutoBuyTab:CreateToggle({
          spawn(function()
             while AutoBuyEnabled do
                AutoBuyBrainrots()
-               wait(10) -- Vérifier toutes les 10 secondes pour éviter spam
+               task.wait(10) -- Vérifier toutes les 10 secondes pour éviter spam
             end
          end)
       else


### PR DESCRIPTION
## Summary
- replace deprecated wait calls with task.wait in scripts and guides

## Testing
- `luac -p steal_brainrot.lua` *(fails: steal_brainrot.lua:410: no loop to break near 'end')*

------
https://chatgpt.com/codex/tasks/task_b_68c5f36081f8832682208428fb788523